### PR TITLE
feat: add query for device identifier

### DIFF
--- a/graphql/resolvers/devicesResolver.ts
+++ b/graphql/resolvers/devicesResolver.ts
@@ -3,7 +3,6 @@ import {
   AddDeviceActivityInput,
   AddDeviceModelInput,
   DBDeviceModel,
-  DeviceModel,
   EditDeviceModelInput,
   addDeviceActivity,
   addNewDevice,
@@ -12,7 +11,7 @@ import {
   getAllAvailableDevices,
   getAllDevices,
   getDeviceById,
-  getDevicePromotions,
+  getDevicePromotions, getDeviceByDeviceUniqueId,
 } from '../../models/devicesModel';
 import supabase from '../../supabase';
 import { doesDeviceExists } from '../utils/checkValuesHandlers';
@@ -48,6 +47,7 @@ export const devicesResolver = {
         payload: { groupId: string; deviceStatusChanged: unknown },
         args: { groupId: string },
       ) => {
+        console.log("Solving")
         if (payload.groupId === args.groupId) {
           return {
             deviceId: payload.deviceStatusChanged,
@@ -69,7 +69,8 @@ export const devicesResolver = {
     ) => getAllAvailableDevices(input ?? {}),
     getDeviceById: (_: undefined, { deviceId }: { deviceId: string }) =>
       getDeviceById(deviceId),
-
+    getDeviceByDeviceUniqueId: (_: undefined, { identifier }: { identifier: string }) =>
+      getDeviceByDeviceUniqueId(identifier),
     getDevicePromotions: async (
       _: undefined,
       { deviceId }: { deviceId: string },
@@ -128,7 +129,6 @@ export const devicesResolver = {
       { input }: { input: EditDeviceModelInput },
     ) => {
       const data = await editDevice(input);
-
       const teamId = data.driver.teamId;
       pubsub.publish('DEVICE_STATUS_CHANGED', {
         deviceStatusChanged: input.deviceId,

--- a/graphql/resolvers/devicesResolver.ts
+++ b/graphql/resolvers/devicesResolver.ts
@@ -47,7 +47,6 @@ export const devicesResolver = {
         payload: { groupId: string; deviceStatusChanged: unknown },
         args: { groupId: string },
       ) => {
-        console.log("Solving")
         if (payload.groupId === args.groupId) {
           return {
             deviceId: payload.deviceStatusChanged,

--- a/graphql/types/devicesTypes.ts
+++ b/graphql/types/devicesTypes.ts
@@ -87,6 +87,7 @@ type Query {
   getAllDevices(input: GetAllDevicesInput): GetAllDevicesResponse!
   getAllAvailableDevices(input: GetAllDevicesInput):GetAllDevicesResponse
   getDeviceById(deviceId: String!): DeviceModel
+  getDeviceByDeviceUniqueId(identifier: String!): DeviceModel
   getDevicePromotions(deviceId: String!): GetDevicePromotionsResponse
 }
 

--- a/models/devicesModel.ts
+++ b/models/devicesModel.ts
@@ -10,7 +10,6 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import tz from 'dayjs/plugin/timezone';
 import { TeamModel } from './teamsModel';
-import { createDeviceUserAssociation } from '../graphql/utils/associationsHandlers';
 import _ from 'lodash';
 
 dayjs.extend(utc);
@@ -109,6 +108,21 @@ export const getDeviceById = async (deviceId: string) => {
     .from('devices')
     .select('*, users(*)')
     .eq('id', deviceId)
+    .single();
+
+  const handledResult = queryResultHandler({
+    query: dataQuery,
+    status: 404,
+  }) as DeviceModelReturnType;
+
+  return devicesMappingFunctions(handledResult);
+};
+
+export const getDeviceByDeviceUniqueId = async (deviceUniqueId: string) => {
+  const dataQuery = await supabase
+    .from('devices')
+    .select('*, users(*)')
+    .eq('identifier', deviceUniqueId)
     .single();
 
   const handledResult = queryResultHandler({


### PR DESCRIPTION
The identifier will be tablet's unique ID. With this the devices won't have to be configured with an ID manually. If their identifier doesn't exist in the DB a new entry will be created for it